### PR TITLE
Replace lodash.template package with lodash itself due to advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "broccoli-plugin": "^1.3.1",
     "fs-tree-diff": "^0.5.9",
-    "lodash.template": "^4.4.0",
+    "lodash": "^4.17.21",
     "rimraf": "^2.6.2",
     "walk-sync": "^0.3.3"
   },

--- a/template-file.js
+++ b/template-file.js
@@ -37,7 +37,7 @@ module.exports = class TemplateFile {
       return this.__template;
     }
 
-    const templater = require('lodash.template');
+    const templater = require('lodash/template');
     return (this.__template = templater(fs.readFileSync(this.path)));
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,22 +593,10 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
-lodash._reinterpolate@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-
-lodash.template@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
-  dependencies:
-    lodash._reinterpolate "~3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz#2b4d4e95ba440d915ff08bc899e4553666713316"
-  dependencies:
-    lodash._reinterpolate "~3.0.0"
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 longest@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
[CVE-2021-23337](https://github.com/advisories/GHSA-35jh-r3h4-6jhm) was recently updated to reflect an issue previously patched in Lodash also being present in the `lodash.template` package, which from all appearances is [no longer maintained](https://github.com/lodash/lodash/issues/5738#issuecomment-1737782579), resulting in users receiving NPM/GitHub alerts related to this advisory.

While the risk of this issue in relation to `broccoli-templater`'s use of `lodash.template` is unclear, it is still seems to me to be worth fixing as a matter of good code hygiene. However, it necessitates replacing `lodash.template` with the latest full version of `lodash` and using the `template` method from there instead.